### PR TITLE
Updated Steering to use WASD

### DIFF
--- a/src/player.cc
+++ b/src/player.cc
@@ -76,8 +76,8 @@ void Player::update() {
 }
 
 void Player::steer() {
-	if ( IsKeyDown(KEY_UP) ) position.y += steer_speed;
-	if ( IsKeyDown(KEY_DOWN) ) position.y -= steer_speed;
+	if ( IsKeyDown(KEY_UP) || IsKeyDown(KEY_W) ) position.y += steer_speed;
+	if ( IsKeyDown(KEY_DOWN) || IsKeyDown(KEY_S) ) position.y -= steer_speed;
 
 	if (position.y > hill.road_width) position.y = hill.road_width;
 	if (position.y < 0) position.y = 0;

--- a/src/raylib_game.cc
+++ b/src/raylib_game.cc
@@ -247,8 +247,8 @@ void Player::update() {
 }
 
 void Player::steer() {
-	if ( IsKeyDown(KEY_UP) ) position.y += steer_speed;
-	if ( IsKeyDown(KEY_DOWN) ) position.y -= steer_speed;
+	if ( IsKeyDown(KEY_UP) || IsKeyDown(KEY_W) ) position.y += steer_speed;
+	if ( IsKeyDown(KEY_DOWN) || IsKeyDown(KEY_S) ) position.y -= steer_speed;
 
 	if (position.y > hill.road_width) position.y = hill.road_width;
 	if (position.y < 0) position.y = 0;


### PR DESCRIPTION
In player.cc and raylib_game.cc, any reference to IsKeyDown(KEY_UP) or IsKeyDown(KEY_DOWN) is now combined with IsKeyDown(KEY_W) and IsKeyDown(KEY_S) respectively. This way users can use WASD style controls again, and avoid scrolling the Itch page. If you take this pull, please update the Itch page to reflect the additional control scheme.

And good luck!